### PR TITLE
Fix container name bug. 

### DIFF
--- a/ecosystem_tests/dorkl/__init__.py
+++ b/ecosystem_tests/dorkl/__init__.py
@@ -18,8 +18,8 @@
 from ecosystem_tests.dorkl.commands import (
     cloudify_exec,
     handle_process,
-    export_secret_to_environment)
-
+    export_secret_to_environment,
+    replace_plugin_package_on_manager)
 from ecosystem_tests.dorkl.runners import (
     prepare_test,
     prepare_test_dev,

--- a/ecosystem_tests/dorkl/commands.py
+++ b/ecosystem_tests/dorkl/commands.py
@@ -24,7 +24,7 @@ from datetime import datetime, timedelta
 
 from ecosystem_tests.dorkl.constansts import (logger,
                                               TIMEOUT,
-                                              MANAGER_CONTAINER_NAME)
+                                              MANAGER_CONTAINER_ENVAR_NAME)
 from ecosystem_tests.dorkl.exceptions import (EcosystemTimeout,
                                               EcosystemTestException)
 from ecosystem_cicd_tools.validations import validate_plugin_version
@@ -98,8 +98,7 @@ def docker_exec(cmd, timeout=TIMEOUT, log=True, detach=False):
     :return: The command output.
     """
 
-    container_name = os.environ.get(
-        'DOCKER_CONTAINER_ID', MANAGER_CONTAINER_NAME)
+    container_name = get_manager_container_name()
     return handle_process(
         'docker exec {container_name} {cmd}'.format(
             container_name=container_name, cmd=cmd), timeout, log, detach)
@@ -173,7 +172,7 @@ def copy_file_to_docker(local_file_path):
     docker_path = os.path.join('/tmp/', os.path.basename(local_file_path))
     handle_process(
         'docker cp {0} {1}:{2}'.format(local_file_path,
-                                       MANAGER_CONTAINER_NAME,
+                                       get_manager_container_name(),
                                        docker_path))
     return docker_path
 
@@ -195,7 +194,7 @@ def copy_directory_to_docker(local_file_path):
     try:
         handle_process(
             'docker cp {0} {1}:/tmp'.format(local_dir,
-                                            MANAGER_CONTAINER_NAME))
+                                            get_manager_container_name()))
     except EcosystemTestException:
         pass
     return remote_dir
@@ -239,3 +238,7 @@ def export_secret_to_environment(name):
     if isinstance(value, bytes):
         value = value.decode(encoding='UTF-8')
     os.environ[name.upper()] = value
+
+
+def get_manager_container_name():
+    return os.environ.get(MANAGER_CONTAINER_ENVAR_NAME, 'cfy_manager')

--- a/ecosystem_tests/dorkl/constansts.py
+++ b/ecosystem_tests/dorkl/constansts.py
@@ -13,15 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import logging
 logging.basicConfig()
 logger = logging.getLogger('logger')
 logger.setLevel(logging.DEBUG)
 
 MANAGER_CONTAINER_ENVAR_NAME = 'MANAGER_CONTAINER'
-MANAGER_CONTAINER_NAME = os.environ.get(MANAGER_CONTAINER_ENVAR_NAME,
-                                        'cfy_manager')
 TIMEOUT = 1800
 VPN_CONFIG_PATH = '/tmp/vpn.conf'
 LICENSE_ENVAR_NAME = 'TEST_LICENSE'

--- a/ecosystem_tests/ecosystem_tests_cli/commands/local_blueprint_test.py
+++ b/ecosystem_tests/ecosystem_tests_cli/commands/local_blueprint_test.py
@@ -15,7 +15,6 @@
 
 from nose.tools import nottest
 
-from ..exceptions import EcosystemTestCliException
 from ...ecosystem_tests_cli import ecosystem_tests
 from ...dorkl.runners import basic_blueprint_test_dev
 from ..utilities import (prepare_test_env,

--- a/ecosystem_tests/ecosystem_tests_cli/constants.py
+++ b/ecosystem_tests/ecosystem_tests_cli/constants.py
@@ -15,7 +15,6 @@
 
 from ..dorkl.constansts import (TIMEOUT,
                                 LICENSE_ENVAR_NAME,
-                                MANAGER_CONTAINER_NAME,
                                 MANAGER_CONTAINER_ENVAR_NAME)
 
 DEFAULT_BLUEPRINT_PATH = 'blueprint.yaml'

--- a/ecosystem_tests/ecosystem_tests_cli/ecosystem_tests.py
+++ b/ecosystem_tests/ecosystem_tests_cli/ecosystem_tests.py
@@ -26,8 +26,7 @@ from .secrets import (secrets_to_dict,
                       encoded_secrets_to_dict)
 from .constants import (TIMEOUT,
                         DEFAULT_LICENSE_PATH,
-                        DEFAULT_BLUEPRINT_PATH,
-                        MANAGER_CONTAINER_NAME)
+                        DEFAULT_BLUEPRINT_PATH)
 
 CLICK_CONTEXT_SETTINGS = dict(
     help_option_names=['-h', '--help'])

--- a/ecosystem_tests/ecosystem_tests_cli/main.py
+++ b/ecosystem_tests/ecosystem_tests_cli/main.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .logger import logger
 from ..ecosystem_tests_cli import ecosystem_tests
 from .commands import (validate_blueprint,
                        local_blueprint_test,

--- a/ecosystem_tests/ecosystem_tests_cli/secrets.py
+++ b/ecosystem_tests/ecosystem_tests_cli/secrets.py
@@ -18,7 +18,6 @@ import base64
 
 from nose.tools import nottest
 
-from .logger import logger
 from .utilities import parse_key_value_pair
 from .exceptions import EcosystemTestCliException
 

--- a/ecosystem_tests/ecosystem_tests_cli/utilities.py
+++ b/ecosystem_tests/ecosystem_tests_cli/utilities.py
@@ -21,8 +21,8 @@ import functools
 from nose.tools import nottest
 
 from .exceptions import EcosystemTestCliException
+from ..dorkl.commands import get_manager_container_name
 from .constants import (LICENSE_ENVAR_NAME,
-                        MANAGER_CONTAINER_NAME,
                         MANAGER_CONTAINER_ENVAR_NAME)
 
 
@@ -44,7 +44,7 @@ def prepare_test_env(func):
         old_environ = dict(os.environ)
         os.environ.update({LICENSE_ENVAR_NAME: kwargs.get('license', '')})
         os.environ.update({MANAGER_CONTAINER_ENVAR_NAME: kwargs.get(
-            'container_name', MANAGER_CONTAINER_NAME)})
+            'container_name', get_manager_container_name())})
         os.environ.update(kwargs.get('secret', {}))
         os.environ.update(kwargs.get('file_secret', {}))
         os.environ.update(kwargs.get('encoded_secret', {}))


### PR DESCRIPTION
Removed MANAGER_CONTAINER_NAME  variable from constants.
because it depends on os.environ we want to evaluate it each time we want to find the current container name.