### PR TITLE
increase-polling-timeout

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,4 @@
+2.8.10: Increase polling timeout while checking if a plugin version got relased to marketplace.
 2.8.9: Skip Bundle Upload by Default.
 2.8.8: RD-6183 add function check_version_valid
 2.8.7: Make sure no yaml.md5 nonsense.

--- a/ecosystem_cicd_tools/new_cicd/actions.py
+++ b/ecosystem_cicd_tools/new_cicd/actions.py
@@ -67,7 +67,7 @@ def upload_assets_to_release(assets, release_name, repository, **_):
 
     # Time to wait for the plugin to load
     # And checking that everything was updated correctly
-    max_time = 180  # it should not take longer than 180 seconds.
+    max_time = 360  # it should not take longer than 360 seconds.
     min_time = 20  # It should definitely take longer than 20 seconds.
     interval = 10  # We check every 10 seconds.
     current = 0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cloudify-ecosystem-test',
-    version='2.8.9',
+    version='2.8.10',
     license='LICENSE',
     packages=find_packages(),
     description='Stuff that Ecosystem Tests Use',


### PR DESCRIPTION
a shot in the dark [ if it doesn't help will go higher , but then it means scraping needs some tuning ] , to address 
```
  File "/home/circleci/.local/lib/python3.6/site-packages/ecosystem_tests/ecosystem_tests_cli/commands/upload_assets.py", line 67, in upload_assets
    actions.upload_assets_to_release(**kwargs)
  File "/home/circleci/.local/lib/python3.6/site-packages/ecosystem_cicd_tools/new_cicd/github.py", line 24, in wrapper_func
    return func(*args, **kwargs)
  File "/home/circleci/.local/lib/python3.6/site-packages/ecosystem_cicd_tools/new_cicd/actions.py", line 80, in upload_assets_to_release
    'Timed out waiting for marketplace plugin update.')
RuntimeError: Timed out waiting for marketplace plugin update
```